### PR TITLE
Fix for broken configs/URLs

### DIFF
--- a/Dynmap/DynMap.cs
+++ b/Dynmap/DynMap.cs
@@ -31,7 +31,7 @@ namespace Dynmap
             var URLFile = "standalone/config.js";
             Trace.WriteLine($"Fetching: {URLFile}");
             var URL_JS = await Client.GetStringAsync(URLFile);
-            var Match = Regex.Match(URL_JS, "url : (.+)};", RegexOptions.Singleline);
+            var Match = Regex.Match(URL_JS, "url\\s*:\\s*(.+)};", RegexOptions.Singleline);
             URLs = JsonConvert.DeserializeObject<URL>(Match.Groups[1].Value);
 
             var ConfigFile = ApplyTimestamp(URLs.Configuration);

--- a/DynmapImageExport/TileDownloader.cs
+++ b/DynmapImageExport/TileDownloader.cs
@@ -53,7 +53,7 @@ namespace DynmapImageExport
             try
             {
                 await Semaphore.WaitAsync();
-                var URL = tile.TilePath();
+                var URL = Tiles.Source.TilesURI + tile.TilePath();
                 Trace.WriteLine($"Downloading tile: {URL} ");
                 var Responce = await Client.GetAsync(URL);
                 if (!Responce.IsSuccessStatusCode)


### PR DESCRIPTION
This tweak should fix downloading tiles for Dynmaps with broken config.js. Some dynmaps minify their configs for no reason (example: https://earthmc.net/map/nova/standalone/config.js). Also second tweak is fetching from appriopriate URL. In case of earthmc.net/map/aurora/, only my solution works
In the original release, merging maps from (at least) this page return "Sequence contains no elements" or "Object reference not set to an instance of an object"